### PR TITLE
Add sitemap configuration to configuration file

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -20,6 +20,9 @@
     }
   ],
   "build": {
+    "sitemap": {
+      "baseUrl": "https://api.playnite.link/docs/"
+    },
     "content": [
       {
         "files": [


### PR DESCRIPTION
Just a small update. I just tried searching on google for something in the manual and for some reason it's linking to the old locations:

![image](https://github.com/JosefNemec/PlayniteDocs/assets/1389286/efeb0224-fae1-4ee4-8dd8-3cb2fb25a586)

From a quick search I stumbled upon [this](https://github.com/dotnet/docfx/issues/1979) and the reason could be that the docs lack a sitemap.

This PR helps to generate the [sitemap](https://dotnet.github.io/docfx/docs/config.html#sitemap) while building the site, I don't know if it will fix the issue of Google not picking it up but it won't hurt and I think it's good practice to have one.


---

Example of generate `sitemap.xml` file:

```xml
<?xml version="1.0" encoding="utf-8"?>
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
  <url>
    <loc>https://api.playnite.link/docs/api/index.html</loc>
    <lastmod>2023-10-09T05:52:39-06:00</lastmod>
    <changefreq>daily</changefreq>
    <priority>0.5</priority>
  </url>
  <url>
    <loc>https://api.playnite.link/docs/changelog.html</loc>
    <lastmod>2023-10-09T05:52:39-06:00</lastmod>
    <changefreq>daily</changefreq>
    <priority>0.5</priority>
  </url>
   ...
```